### PR TITLE
[Optimization] Optional data

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -83,26 +83,6 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        if (!(arePrefixesPresent(argMultimap, PREFIX_PHONE)
-                || (arePrefixesPresent(argMultimap, PREFIX_PHONE_PRIVATE)))) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-        }
-
-        if (!(arePrefixesPresent(argMultimap, PREFIX_EMAIL)
-                || (arePrefixesPresent(argMultimap, PREFIX_EMAIL_PRIVATE)))) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-        }
-
-        if (!(arePrefixesPresent(argMultimap, PREFIX_ADDRESS)
-                || (arePrefixesPresent(argMultimap, PREFIX_ADDRESS_PRIVATE)))) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-        }
-
-        if (!(arePrefixesPresent(argMultimap, PREFIX_REMARK)
-                || (arePrefixesPresent(argMultimap, PREFIX_REMARK_PRIVATE)))) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-        }
-
         try {
             Name name;
             Phone phone;
@@ -118,27 +98,36 @@ public class AddCommandParser implements Parser<AddCommand> {
 
             if ((arePrefixesPresent(argMultimap, PREFIX_PHONE))) {
                 phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE)).get();
-            } else {
+            } else if (arePrefixesPresent(argMultimap, PREFIX_PHONE_PRIVATE)) {
                 phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE_PRIVATE), true).get();
+            } else {
+                phone = new Phone(null);
             }
 
             if ((arePrefixesPresent(argMultimap, PREFIX_EMAIL))) {
                 email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL)).get();
-            } else {
+            } else if (arePrefixesPresent(argMultimap, PREFIX_EMAIL_PRIVATE)) {
                 email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL_PRIVATE), true).get();
+            } else {
+                email = new Email(null);
             }
 
             if ((arePrefixesPresent(argMultimap, PREFIX_ADDRESS))) {
                 address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS)).get();
-            } else {
+            } else if (arePrefixesPresent(argMultimap, PREFIX_ADDRESS_PRIVATE)) {
                 address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS_PRIVATE), true).get();
+            } else {
+                address = new Address(null);
             }
 
             if ((arePrefixesPresent(argMultimap, PREFIX_REMARK))) {
                 remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK)).get();
-            } else {
+            } else if (arePrefixesPresent(argMultimap, PREFIX_REMARK_PRIVATE)) {
                 remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK_PRIVATE), true).get();
+            } else {
+                remark = new Remark(null);
             }
+
             Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
             ReadOnlyPerson person = new Person(name, phone, email, address, false, remark, tagList);
             return person;
@@ -158,28 +147,27 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_TASK_USAGE));
         }
 
-        if (!(arePrefixesPresent(argMultimap, PREFIX_DESCRIPTION))) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_TASK_USAGE));
-        }
-
-        if (!(arePrefixesPresent(argMultimap, PREFIX_DEADLINE))) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_TASK_USAGE));
-        }
-
-        if (!(arePrefixesPresent(argMultimap, PREFIX_PRIORITY))) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_TASK_USAGE));
-        }
-
         try {
             TaskName name;
             Description description;
             Deadline deadline;
             Priority priority;
 
-            name = ParserUtil.parseTaskName(argMultimap.getValue(PREFIX_NAME)).get();
-            description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION)).get();
-            deadline = ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_DEADLINE)).get();
-            priority = ParserUtil.parsePriority(argMultimap.getValue(PREFIX_PRIORITY)).get();
+            name = arePrefixesPresent(argMultimap, PREFIX_NAME)
+                    ? ParserUtil.parseTaskName(argMultimap.getValue(PREFIX_NAME)).get()
+                    : new TaskName(null);
+
+            description = arePrefixesPresent(argMultimap, PREFIX_DESCRIPTION)
+                    ? ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION)).get()
+                    : new Description(null);
+
+            deadline = arePrefixesPresent(argMultimap, PREFIX_DEADLINE)
+                    ? ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_DEADLINE)).get()
+                    : new Deadline(null);
+
+            priority = arePrefixesPresent(argMultimap, PREFIX_PRIORITY)
+                    ? ParserUtil.parsePriority(argMultimap.getValue(PREFIX_PRIORITY)).get()
+                    : new Priority(null);
 
 
             ReadOnlyTask task = new Task(name, description, deadline, priority);

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -147,18 +147,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, AddCommand.COMMAND_WORD + VALID_NAME_BOB + PHONE_DESC_BOB
                 + EMAIL_DESC_BOB + ADDRESS_DESC_BOB, expectedMessage);
 
-        // missing phone prefix
-        assertParseFailure(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + VALID_PHONE_BOB
-                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB, expectedMessage);
-
-        // missing email prefix
-        assertParseFailure(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB
-                + VALID_EMAIL_BOB + ADDRESS_DESC_BOB, expectedMessage);
-
-        // missing address prefix
-        assertParseFailure(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB
-                + EMAIL_DESC_BOB + VALID_ADDRESS_BOB, expectedMessage);
-
         // all prefixes missing
         assertParseFailure(parser, AddCommand.COMMAND_WORD + VALID_NAME_BOB + VALID_PHONE_BOB
                 + VALID_EMAIL_BOB + VALID_ADDRESS_BOB, expectedMessage);
@@ -171,18 +159,6 @@ public class AddCommandParserTest {
         // missing task name prefix
         assertParseFailure(parser, AddCommand.COMMAND_WORD + TASK_SEPARATOR + VALID_TASK_NAME_PAPER
                 + DESCRIPTION_DESC_PENCIL + DEADLINE_DESC_PENCIL + PRIORITY_DESC_PENCIL, expectedMessage);
-
-        // missing description prefix
-        assertParseFailure(parser, AddCommand.COMMAND_WORD + TASK_SEPARATOR + TASK_NAME_DESC_PENCIL
-                + VALID_DESCRIPTION_PENCIL + DEADLINE_DESC_PENCIL + PRIORITY_DESC_PENCIL, expectedMessage);
-
-        // missing deadline prefix
-        assertParseFailure(parser, AddCommand.COMMAND_WORD + TASK_SEPARATOR + TASK_NAME_DESC_PENCIL
-                + DESCRIPTION_DESC_PENCIL + VALID_DEADLINE_PENCIL + PRIORITY_DESC_PENCIL, expectedMessage);
-
-        // missing priority prefix
-        assertParseFailure(parser, AddCommand.COMMAND_WORD + TASK_SEPARATOR + TASK_NAME_DESC_PENCIL
-                + DESCRIPTION_DESC_PENCIL + DEADLINE_DESC_PENCIL + VALID_PRIORITY_PENCIL, expectedMessage);
 
         // all prefixes missing
         assertParseFailure(parser, AddCommand.COMMAND_WORD + TASK_SEPARATOR + VALID_TASK_NAME_PENCIL

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -157,18 +157,6 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         command = AddCommand.COMMAND_WORD + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + REMARK_DESC_AMY;
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
-        /* Case: missing phone -> rejected */
-        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + REMARK_DESC_AMY;
-        assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-
-        /* Case: missing email -> rejected */
-        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + REMARK_DESC_AMY;
-        assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-
-        /* Case: missing address -> rejected */
-        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + REMARK_DESC_AMY;
-        assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-
         /* Case: invalid keyword -> rejected */
         command = "adds " + PersonUtil.getPersonDetails(toAdd);
         assertCommandFailure(command, Messages.MESSAGE_UNKNOWN_COMMAND);


### PR DESCRIPTION
Adding on to #14 

The need to key in the prefixes even if they weren't going to be used makes data entry a highly vexing process, especially with more and more fields being added.
Now users don't need to key in the prefix when adding tasks or persons anymore.